### PR TITLE
Fixed critical bug with product availability

### DIFF
--- a/VirtoCommerce.LiquidThemeEngine/Converters/ProductConverter.cs
+++ b/VirtoCommerce.LiquidThemeEngine/Converters/ProductConverter.cs
@@ -39,9 +39,9 @@ namespace VirtoCommerce.LiquidThemeEngine.Converters
             if (product.Variations != null && product.Variations.Any())
             {
                 result.Variants.AddRange(product.Variations.Select(x => x.ToVariant()));
-                result.Available = product.Variations.Any(v => v.IsAvailable);
-                result.Buyable = product.Variations.Any(v => v.IsBuyable);
-                result.InStock = product.Variations.Any(v => v.IsInStock);
+                result.Available = product.IsAvailable || product.Variations.Any(v => v.IsAvailable);
+                result.Buyable = product.IsBuyable || product.Variations.Any(v => v.IsBuyable);
+                result.InStock = product.IsInStock || product.Variations.Any(v => v.IsInStock);
             }
             else
             {


### PR DESCRIPTION
Before this fix, if product had variations, its availability was calculated using only these variations availability, but excluding product itself availability

Where exist first time: VirtoCommerce/vc-storefront@c97f735
When shouldn't pass quality gate after: VirtoCommerce/vc-storefront-core@f65b2a5