### PR TITLE
Do not logout anonymous user when cookie expire

### DIFF
--- a/VirtoCommerce.Storefront/Domain/Security/SecurityWorkContextBuilderExtensions.cs
+++ b/VirtoCommerce.Storefront/Domain/Security/SecurityWorkContextBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -47,7 +47,7 @@ namespace VirtoCommerce.Storefront.Domain.Security
                 if (!builder.HttpContext.Request.Path.Value.EndsWith(".map"))
                 {
                     //Sign-in anonymous user
-                    await signInManager.SignInAsync(user, false);
+                    await signInManager.SignInAsync(user, new AuthenticationProperties { IsPersistent = false, ExpiresUtc = DateTimeOffset.MaxValue });
                     //https://github.com/aspnet/Security/issues/1131
                     //the sign in operation doesn't change the current request user principal.
                     //That only happens on incoming requests once the cookie or bearer token (or whatever thing the type of auth requires to create an identity) is set.


### PR DESCRIPTION
When customers browse storefront anonymously, we login they as special ASP.NET user. And as usual user, anonymous may be logged out after specified period of inactivity. Also, if you will open login page, leave for some time and then enter credentials and try to login, you will get 400 error page because anitforgery token will be invalid (it still valid until cookie not expired). To prevent this, set the life time of anonymous user cookie to infinity (because DateTime has no such value, I use max possible value)