### PR TITLE
Different name, changed every occurence of vc-storefront to vc-storefront-core.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Key features:
 3. Default ASP.NET Core [in-memory caching](https://docs.microsoft.com/en-us/aspnet/core/performance/caching/memory) completely replaced the [CacheManager](http://cachemanager.michaco.net/) used before.
 4. New more selective cache invalidation based on usage of `CancellationChangeToken` and strongly typed cache regions allows to display always actual content without performance lossing.
 5. New framework for working with domain events.
-6. Usage of [ASP.NET Core middlewares](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware) 
+6. Usage of [ASP.NET Core middlewares](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware)
 7. Reworked the WorkContext initialization, it made more fluently.
 8. Usage of the latest version of [Microsoft AutoRest](https://github.com/Azure/autorest)
 9. Usage  of [ASP.NET Core Response Caching Middleware](https://docs.microsoft.com/en-us/aspnet/core/performance/caching/middleware) for FPC (full page caching).
 10. Use [Build-in ASP.NET Dependency Injection](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection) instead Unity DI and IoC container.
 
-# Sample themes 
+# Sample themes
 
 ## [Default theme](https://github.com/VirtoCommerce/vc-theme-default)
 ![electronics](https://user-images.githubusercontent.com/7566324/31821605-f36d17de-b5a5-11e7-9bb5-a71803285d8b.png)
@@ -58,7 +58,7 @@ Setup your own private Microsoft Cloud environment and evaluate the latest versi
 
 ## Source code getting started
 
-### Prerequisites 
+### Prerequisites
 [Prerequisites for .NET Core on Windows](https://docs.microsoft.com/en-us/dotnet/core/windows-prerequisites)
 
 [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=53840) (required for SCSS engine)
@@ -71,38 +71,38 @@ Fork your own copy of VirtoCommerce Storefront to your account on GitHub:
 If you are a member of an organization on GitHub, select the target for the fork.
 2. Clone the forked repository to local machine:
 ```
-git clone https://github.com/<<your GitHub user name>>/vc-storefront.git C:\vc-storefront
+git clone https://github.com/<<your GitHub user name>>/vc-storefront-core.git C:\vc-storefront
 ```
 3. Switch to the cloned directory:
 
-```cd C:\vc-storefront```
+```cd C:\vc-storefront-core```
 
 4. Add a reference to the original repository:
 
-```git remote add upstream https://github.com/VirtoCommerce/vc-storefront.git```
+```git remote add upstream https://github.com/VirtoCommerce/vc-storefront-core.git```
 
-In result you should get the C:\vc-storefront folder which contains full storefront source code. To retrieve changes from original Virto Commerce Storefront repository, merge upstream/master branch.
+In result you should get the C:\vc-storefront-core folder which contains full storefront source code. To retrieve changes from original Virto Commerce Storefront repository, merge upstream/master branch.
 
 ### Configuring VirtoCommerce Platform Endpoint
-Set actual platform endpoint values in the C:\vc-storefront\VirtoCommerce.Storefront\appsettings.json.
+Set actual platform endpoint values in the C:\vc-storefront-core\VirtoCommerce.Storefront\appsettings.json.
 Read more about how to generate API keys [here](https://virtocommerce.com/docs/vc2devguide/development-scenarios/working-with-platform-api)
 
-``` 
+```
  ...
   "VirtoCommerce": {
     "Endpoint": {
-	   //Virto Commerce platform manager url 
+	   //Virto Commerce platform manager url
       "Url": "http://localhost/admin",
 	   //HMAC authentification user credentials on whose behalf the API calls will be made.
-      "AppId": "Enter your AppId here" 
+      "AppId": "Enter your AppId here"
       "SecretKey": "Enter your SecretKey here",
     }
 	...
 ```
-ASP.NET Core represents a new tools a **Secret Manager tool**, which allows in development to keep secrets out of your code. 
+ASP.NET Core represents a new tools a **Secret Manager tool**, which allows in development to keep secrets out of your code.
 You can find more about them [here](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?tabs=visual-studio)
 
-### Configure themes 
+### Configure themes
 Storefront  **appsettings.json** file contains **ContentConnectionString** setting with pointed to the folder with actual themes and pages content
 ```
 ...
@@ -117,14 +117,14 @@ Storefront  **appsettings.json** file contains **ContentConnectionString** setti
 You can set this connection string in one of the following ways:
 1. If you have already have installed  platform with sample data, your platform already contains `~/App_Data/cms-content` folder with themes for sample stores and you need only to make symbolic link to this folder by this command:
 ```
-mklink /d C:\vc-storefront\VirtoCommerce.Storefront\wwwroot\cms-content C:\vc-platform\VirtoCommerce.Platform.Web\App_Data\cms-content
+mklink /d C:\vc-storefront-core\VirtoCommerce.Storefront\wwwroot\cms-content C:\vc-platform\VirtoCommerce.Platform.Web\App_Data\cms-content
 ```
-2. If you did not install sample data with your platform, you need to create new store in platform manager and download themes as it described in this article 
+2. If you did not install sample data with your platform, you need to create new store in platform manager and download themes as it described in this article
 [Theme development](https://virtocommerce.com/docs/vc2devguide/working-with-storefront/theme-development)
 
-### Host on Windows with IIS 
-VirtoCommerce.Storefront project already include the **web.config** file with all necessary settings for runing in IIS. 
-How to configure IIS application to host ASP.NET Core site please learn more in the official Microsoft ASP.NET Core documentation 
+### Host on Windows with IIS
+VirtoCommerce.Storefront project already include the **web.config** file with all necessary settings for runing in IIS.
+How to configure IIS application to host ASP.NET Core site please learn more in the official Microsoft ASP.NET Core documentation
 [Host ASP.NET Core on Windows with IIS](https://docs.microsoft.com/en-us/aspnet/core/publishing/iis)
 
 # License

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Fork your own copy of VirtoCommerce Storefront to your account on GitHub:
 If you are a member of an organization on GitHub, select the target for the fork.
 2. Clone the forked repository to local machine:
 ```
-git clone https://github.com/<<your GitHub user name>>/vc-storefront-core.git C:\vc-storefront
+git clone https://github.com/<<your GitHub user name>>/vc-storefront-core.git C:\vc-storefront-core
 ```
 3. Switch to the cloned directory:
 


### PR DESCRIPTION
In case someone's using the old vc-storefront's binaries, I've added the correct naming, because if he doesn't notice, he'll link to his old storefront.