### PR TITLE
161: added some routing tests

### DIFF
--- a/VirtoCommerce.Storefront.Tests/Routing/Infrastructure/RoutingDataResult.cs
+++ b/VirtoCommerce.Storefront.Tests/Routing/Infrastructure/RoutingDataResult.cs
@@ -19,18 +19,11 @@ namespace VirtoCommerce.Storefront.Tests.Routing.Infrastructure
         /// <param name="controllerMethodName">Fully-qualified name of controller method that would be used
         /// to process request.</param>
         /// <param name="arguments">A name-value dictionary containing arguments passed with the request.</param>
-        public RoutingDataResult(string requestPath, string controllerTypeName, string controllerMethodName, IDictionary<string, object> arguments)
+        public RoutingDataResult(string controllerTypeName, string controllerMethodName)
         {
-            RequestPath = requestPath;
             ControllerTypeName = controllerTypeName;
             ControllerMethodName = controllerMethodName;
-            Arguments = arguments;
         }
-
-        /// <summary>
-        /// Path that was requested by client.
-        /// </summary>
-        public string RequestPath { get; }
 
         /// <summary>
         /// Full type name of controller that would process the request.
@@ -41,10 +34,5 @@ namespace VirtoCommerce.Storefront.Tests.Routing.Infrastructure
         /// Fully-qualified name of controller method that would be used to process request.
         /// </summary>
         public string ControllerMethodName { get; }
-
-        /// <summary>
-        /// A name-value dictionary containing arguments passed with the request.
-        /// </summary>
-        public IDictionary<string, object> Arguments { get; }
     }
 }

--- a/VirtoCommerce.Storefront.Tests/Routing/Infrastructure/RoutingTestingActionFilter.cs
+++ b/VirtoCommerce.Storefront.Tests/Routing/Infrastructure/RoutingTestingActionFilter.cs
@@ -13,11 +13,9 @@ namespace VirtoCommerce.Storefront.Tests.Routing.Infrastructure
         /// <inheritdoc />
         public void OnActionExecuting(ActionExecutingContext context)
         {
-            var requestPath = context.HttpContext.Request.Path;
             var controllerTypeName = context.Controller.GetType().FullName;
             var methodName = context.ActionDescriptor.DisplayName;
-            var arguments = context.ActionArguments;
-            var routingDataResult = new RoutingDataResult(requestPath, controllerTypeName, methodName, arguments);
+            var routingDataResult = new RoutingDataResult(controllerTypeName, methodName);
 
             context.Result = new JsonResult(routingDataResult);
         }

--- a/VirtoCommerce.Storefront.Tests/Routing/RoutingTests.cs
+++ b/VirtoCommerce.Storefront.Tests/Routing/RoutingTests.cs
@@ -397,11 +397,7 @@ namespace VirtoCommerce.Storefront.Tests.Routing
 
                 case CustomHttpMethod.PostForm:
                     var actualData = (IEnumerable<KeyValuePair<string, string>>)objectToPost ?? EmptyFormData;
-                    var request = new HttpRequestMessage(HttpMethod.Post, url)
-                    {
-                        Content = new FormUrlEncodedContent(actualData)
-                    };
-                    return await Client.SendAsync(request);
+                    return await Client.PostAsync(url, new FormUrlEncodedContent(actualData));
 
                 case CustomHttpMethod.Get:
                     return await Client.GetAsync(url);

--- a/VirtoCommerce.Storefront.Tests/Routing/RoutingTests.cs
+++ b/VirtoCommerce.Storefront.Tests/Routing/RoutingTests.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Formatting;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using VirtoCommerce.Storefront.Model;
 using VirtoCommerce.Storefront.Model.Cart;
 using VirtoCommerce.Storefront.Model.Common;
@@ -21,7 +23,7 @@ namespace VirtoCommerce.Storefront.Tests.Routing
     public class RoutingTests : IClassFixture<WebApplicationFactory<Startup>>, IDisposable
     {
         /// <summary>
-        /// HTTP methods merged with POST body type. Added to simplify contents of TestData in RoutingData.
+        /// HTTP methods merged with POST body type. Added to simplify contents of test data in RoutingData.
         /// </summary>
         public enum CustomHttpMethod
         {
@@ -31,6 +33,35 @@ namespace VirtoCommerce.Storefront.Tests.Routing
             Put,
             Delete
         }
+
+        private static readonly Currency TestCurrency = new Currency(new Language("en-US"), "XPT");
+        private static readonly Money EmptyMoney = new Money(0.0m, TestCurrency);
+
+        private static readonly Payment EmptyPayment = new Payment(TestCurrency)
+        {
+            Amount = EmptyMoney,
+            DiscountAmount = EmptyMoney,
+            DiscountAmountWithTax = EmptyMoney,
+            Price = EmptyMoney,
+            PriceWithTax = EmptyMoney,
+            TaxTotal = EmptyMoney,
+            Total = EmptyMoney,
+            TotalWithTax = EmptyMoney
+        };
+
+        private static readonly Shipment EmptyShipment = new Shipment()
+        {
+            Currency = TestCurrency,
+            DiscountAmount = EmptyMoney,
+            DiscountAmountWithTax = EmptyMoney,
+            Price = EmptyMoney,
+            TaxTotal = EmptyMoney,
+            TotalWithTax = EmptyMoney,
+            Total = EmptyMoney,
+            PriceWithTax = EmptyMoney
+        };
+
+        private static readonly Dictionary<string, string> EmptyFormData = new Dictionary<string, string>();
 
         public static readonly IReadOnlyCollection<object[]> RoutingData;
 
@@ -52,11 +83,12 @@ namespace VirtoCommerce.Storefront.Tests.Routing
             AddApiRequestRoute(routingData, "ApiCart", "AddCartCoupon", CustomHttpMethod.PostJson, "storefrontapi/cart/coupons/TESTCOUPON");
 
             AddApiRequestRoute(routingData, "ApiCart", "RemoveCartCoupon", CustomHttpMethod.Delete, "storefrontapi/cart/coupons");
-            AddApiRequestRoute(routingData, "ApiCart", "AddOrUpdateCartShipment", CustomHttpMethod.PostJson, "storefrontapi/cart/shipments", new Shipment());
+            AddApiRequestRoute(routingData, "ApiCart", "AddOrUpdateCartShipment", CustomHttpMethod.PostJson, "storefrontapi/cart/shipments", EmptyShipment);
+            AddApiRequestRoute(routingData, "ApiCart", "AddOrUpdateCartPayment", CustomHttpMethod.PostJson, "storefrontapi/cart/payments", EmptyPayment);
             AddApiRequestRoute(routingData, "ApiCart", "CreateOrder", CustomHttpMethod.PostJson, "storefrontapi/cart/createorder");
             AddApiRequestRoute(routingData, "ApiCart", "AddOrUpdateCartPaymentPlan", CustomHttpMethod.PostJson, "storefrontapi/cart/paymentPlan");
-            AddApiRequestRoute(routingData, "ApiCart", "DeleteCartPaymentPlan", CustomHttpMethod.Delete, "storefrontapi/cart/paymentPlan");
 
+            AddApiRequestRoute(routingData, "ApiCart", "DeleteCartPaymentPlan", CustomHttpMethod.Delete, "storefrontapi/cart/paymentPlan");
             AddApiRequestRoute(routingData, "ApiCart", "UpdateCartComment", CustomHttpMethod.Put, "storefrontapi/cart/comment");
 
             // API lists
@@ -154,24 +186,27 @@ namespace VirtoCommerce.Storefront.Tests.Routing
             AddRegularRequestRoute(routingData, "Account", "GetOrderDetails", CustomHttpMethod.Get, "account/order/{number}");
             AddRegularRequestRoute(routingData, "Account", "GetAddresses", CustomHttpMethod.Get, "account/addresses");
             AddRegularRequestRoute(routingData, "Account", "Register", CustomHttpMethod.Get, "account/register");
-            AddRegularRequestRoute(routingData, "Account", "Login", CustomHttpMethod.Get, "account/login");
+            AddRegularRequestRoute(routingData, "Account", "Register", CustomHttpMethod.PostForm, "account/register");
 
-            AddRegularRequestRoute(routingData, "Account", "Login", CustomHttpMethod.PostForm, "account/login", new Login());
+            AddRegularRequestRoute(routingData, "Account", "Login", CustomHttpMethod.Get, "account/login");
+            AddRegularRequestRoute(routingData, "Account", "Login", CustomHttpMethod.PostForm, "account/login");
             AddRegularRequestRoute(routingData, "Account", "Logout", CustomHttpMethod.Get, "account/logout");
             AddRegularRequestRoute(routingData, "Account", "ForgotPassword", CustomHttpMethod.Get, "account/forgotpassword");
-            AddRegularRequestRoute(routingData, "Account", "ForgotPassword", CustomHttpMethod.PostForm, "account/forgotpassword", new ForgotPassword());
-            AddRegularRequestRoute(routingData, "Account", "ResetPassword", CustomHttpMethod.Get, "account/resetpassword");
+            AddRegularRequestRoute(routingData, "Account", "ForgotPassword", CustomHttpMethod.PostForm, "account/forgotpassword");
 
-            AddRegularRequestRoute(routingData, "Account", "ResetPassword", CustomHttpMethod.PostForm, "account/resetpassword", new ResetPassword());
-            AddRegularRequestRoute(routingData, "Account", "ChangePassword", CustomHttpMethod.PostForm, "account/password", new ChangePassword());
+            AddRegularRequestRoute(routingData, "Account", "ResetPassword", CustomHttpMethod.Get, "account/resetpassword");
+            AddRegularRequestRoute(routingData, "Account", "ResetPassword", CustomHttpMethod.PostForm, "account/resetpassword");
+            AddRegularRequestRoute(routingData, "Account", "ChangePassword", CustomHttpMethod.PostForm, "account/password");
             AddRegularRequestRoute(routingData, "Account", "ExternalLogin", CustomHttpMethod.Get, "account/externallogin");
             AddRegularRequestRoute(routingData, "Account", "ExternalLoginCallback", CustomHttpMethod.Get, "account/externallogincallback");
-            AddRegularRequestRoute(routingData, "Account", "ImpersonateUser", CustomHttpMethod.Get, "account/impersonate/111");
 
+            AddRegularRequestRoute(routingData, "Account", "ImpersonateUser", CustomHttpMethod.Get, "account/impersonate/111");
             AddRegularRequestRoute(routingData, "Account", "ConfirmEmail", CustomHttpMethod.Get, "account/confirmemail");
             AddRegularRequestRoute(routingData, "Account", "ConfirmInvitation", CustomHttpMethod.Get, "account/confirminvitation");
+            AddRegularRequestRoute(routingData, "Account", "ConfirmInvitation", CustomHttpMethod.PostForm, "account/confirminvitation");
             AddRegularRequestRoute(routingData, "Account", "ForgotLogin", CustomHttpMethod.Get, "account/forgotlogin");
-            AddRegularRequestRoute(routingData, "Account", "ForgotLogin", CustomHttpMethod.PostForm, "account/forgotlogin", new ForgotPassword());
+
+            AddRegularRequestRoute(routingData, "Account", "ForgotLogin", CustomHttpMethod.PostForm, "account/forgotlogin");
 
             // Cart
             AddRegularRequestRoute(routingData, "Cart", "Index", CustomHttpMethod.Get, "cart");
@@ -213,11 +248,13 @@ namespace VirtoCommerce.Storefront.Tests.Routing
 
             // Common
             AddRegularRequestRoute(routingData, "Common", "SetCurrency", CustomHttpMethod.Get, "common/setcurrency/USD");
-            AddRegularRequestRoute(routingData, "Common", "ContactForm", CustomHttpMethod.PostForm, "contact/page.contact", new ContactForm());
+            AddRegularRequestRoute(routingData, "Common", "GetCountries", CustomHttpMethod.Get, "common/getcountries/json");
+            AddRegularRequestRoute(routingData, "Common", "GetRegions", CustomHttpMethod.Get, "common/getregions/us/json");
+            AddRegularRequestRoute(routingData, "Common", "ContactForm", CustomHttpMethod.PostForm, "contact/page.contact", EmptyFormData);
             AddRegularRequestRoute(routingData, "Common", "Maintenance", CustomHttpMethod.Get, "maintenance");
+
             AddRegularRequestRoute(routingData, "Common", "Maintenance", CustomHttpMethod.Get, "common/maintenance");
             AddRegularRequestRoute(routingData, "Common", "ResetCache", CustomHttpMethod.Get, "common/resetcache");
-
             AddRegularRequestRoute(routingData, "Common", "NoTheme", CustomHttpMethod.Get, "common/notheme");
 
             // Sitemap
@@ -349,10 +386,22 @@ namespace VirtoCommerce.Storefront.Tests.Routing
             switch (method)
             {
                 case CustomHttpMethod.PostJson:
-                    return await Client.PostAsJsonAsync(url, objectToPost);
+                    var jsonFormatter = new JsonMediaTypeFormatter
+                    {
+                        SerializerSettings = new JsonSerializerSettings
+                        {
+                            ContractResolver = new CamelCasePropertyNamesContractResolver()
+                        }
+                    };
+                    return await Client.PostAsync(url, objectToPost, jsonFormatter);
 
                 case CustomHttpMethod.PostForm:
-                    return await Client.PostAsync(url, new FormUrlEncodedContent(Enumerable.Empty<KeyValuePair<string, string>>()));
+                    var actualData = (IEnumerable<KeyValuePair<string, string>>)objectToPost ?? EmptyFormData;
+                    var request = new HttpRequestMessage(HttpMethod.Post, url)
+                    {
+                        Content = new FormUrlEncodedContent(actualData)
+                    };
+                    return await Client.SendAsync(request);
 
                 case CustomHttpMethod.Get:
                     return await Client.GetAsync(url);


### PR DESCRIPTION
Changes made for #161:
* Added test cases described in #161.
* Reworked `POST` of test JSON data. Now it is translated from `UpperCamelCase` to `lowerCamelCase` to match JS naming convention and make tests more realistic.
* Reworked `POST` of test form data - now it doesn't ignore `objectToPost` passed to the method. It is not used at this moment, though - all methods that use `PostData` method are currently tested with empty data.
* Removed `RequestPath` and `Arguments` properties from `RoutingDataResult`. These properties seemed useful at the moment of `RoutingTestingActionFilter` creation, but tests did not make use of them. In fact, `Arguments` property broke tests of `AccountController.Register` and `AccountController.ConfirmInvitation` action routes:
    1. Test code made HTTP request to test server and sent some form data that could be translated to `UserRegistration` or `UserRegistrationByInvitation` (which is derived from `UserRegistration`).
    2. `RoutingTestingActionFilter` handled this action and returned `RoutingDataResult`. It also added deserialized `UserRegistration` or `UserRegistrationByInvitation` to the `RoutingDataResult.Arguments`.
    3. MVC attempted to serialize returned `RoutingDataResult` and its property values, including `UserRegistration` in `RoutingDataResult.Arguments`.
    4. To serialize `UserRegistration`, it uses a `BackwardCompatibilityJsonConverter` (which claims to handle `UserRegistration` type for some reason).
    5. `BackwardCompatibilityJsonConverter.WriteJson` method attempts to cast `UserRegistration` instance to `User`, receives `null` and attempts to serialize it without further checks. This leads to `ArgumentNullException` described by @asvishnyakov in his [comment to the issue](https://github.com/VirtoCommerce/vc-storefront-core/issues/161#issuecomment-424982960).

This flow might be an issue too, but I don't think that it would happen in the production environment - storefront controllers never send `UserRegistration` back to frontend (and probably never will). So I just removed unused `Arguments` property from the `RoutingDataResult`, and it solved the error.