### PR TITLE
Fix for Money.TruncatedAmount behavior

### DIFF
--- a/VirtoCommerce.Storefront.Model/Common/Money/Money.cs
+++ b/VirtoCommerce.Storefront.Model/Common/Money/Money.cs
@@ -91,7 +91,8 @@ namespace VirtoCommerce.Storefront.Model.Common
         {
             get
             {
-                return (decimal)(long)Math.Truncate(InternalAmount * DecimalDigits) / DecimalDigits;
+                var roundingBase = (decimal)Math.Pow(10, DecimalDigits);
+                return (long)Math.Truncate(InternalAmount * roundingBase) / roundingBase;
             }
         }
 

--- a/VirtoCommerce.Storefront.Tests/Model/MoneyOperationTests.cs
+++ b/VirtoCommerce.Storefront.Tests/Model/MoneyOperationTests.cs
@@ -4,6 +4,7 @@ using StorefrontLanguage = VirtoCommerce.Storefront.Model.Language;
 
 namespace VirtoCommerce.Storefront.Tests.Model
 {
+    [Trait("Category", "CI")]
     public class MoneyOperationTests
     {
         private static readonly StorefrontLanguage TestLanguage = new StorefrontLanguage("en-US");

--- a/VirtoCommerce.Storefront.Tests/Model/MoneyOperationTests.cs
+++ b/VirtoCommerce.Storefront.Tests/Model/MoneyOperationTests.cs
@@ -1,0 +1,40 @@
+using VirtoCommerce.Storefront.Model.Common;
+using Xunit;
+using StorefrontLanguage = VirtoCommerce.Storefront.Model.Language;
+
+namespace VirtoCommerce.Storefront.Tests.Model
+{
+    public class MoneyOperationTests
+    {
+        private static readonly StorefrontLanguage TestLanguage = new StorefrontLanguage("en-US");
+        private static readonly Currency TestCurrency = new Currency(TestLanguage, "TPT", "Test points", "T", 1.0m);
+
+        [Theory]
+        [InlineData(  0.0,     0.0,    0.0,  "T0.00",   "T0",   "0")]
+        [InlineData(  0.99,    0.99,   0.99, "T0.99",   "T1",   "1")]
+        [InlineData(  0.999,   1.00,   0.99, "T1.00",   "T1",   "1")]
+        [InlineData(  1.445,   1.45,   1.44, "T1.45",   "T1",   "1")]
+        [InlineData(  1.455,   1.46,   1.45, "T1.46",   "T1",   "1")]
+        [InlineData( -1.445,  -1.45,  -1.44, "(T1.45)", "(T1)", "(1)")]
+        [InlineData( -1.455,  -1.46,  -1.45, "(T1.46)", "(T1)", "(1)")]
+        [InlineData( 12.34,   12.34,  12.34, "T12.34",  "T12",  "12")]
+        [InlineData( 12.345,  12.35,  12.34, "T12.35",  "T12",  "12")]
+        [InlineData(123.456, 123.46, 123.45, "T123.46", "T123", "123")]
+        [InlineData(123.5,   123.5,  123.5,  "T123.50", "T124", "124")]
+        public void TestGettingMoneyProperties(decimal internalAmount, decimal expectedAmount,
+            decimal expectedTruncatedAmount, string expectedFormattedAmount, string expectedFormattedAmountWithoutPoint,
+            string expectedFormattedAmountWithoutPointAndCurrency)
+        {
+            // Arrange
+            var money = new Money(internalAmount, TestCurrency);
+
+            // Act & Assert
+            Assert.Equal(internalAmount, money.InternalAmount);
+            Assert.Equal(expectedAmount, money.Amount);
+            Assert.Equal(expectedTruncatedAmount, money.TruncatedAmount);
+            Assert.Equal(expectedFormattedAmount, money.FormattedAmount);
+            Assert.Equal(expectedFormattedAmountWithoutPoint, money.FormattedAmountWithoutPoint);
+            Assert.Equal(expectedFormattedAmountWithoutPointAndCurrency, money.FormattedAmountWithoutPointAndCurrency);
+        }
+    }
+}

--- a/VirtoCommerce.Storefront.Tests/ResponseCaching/ResponseCachingTests.cs
+++ b/VirtoCommerce.Storefront.Tests/ResponseCaching/ResponseCachingTests.cs
@@ -11,6 +11,7 @@ using Moq;
 using VirtoCommerce.LiquidThemeEngine;
 using VirtoCommerce.Storefront.Model.Stores;
 using Xunit;
+using Language = VirtoCommerce.Storefront.Model.Language;
 
 namespace VirtoCommerce.Storefront.Tests.OutputCache
 {
@@ -30,7 +31,7 @@ namespace VirtoCommerce.Storefront.Tests.OutputCache
                         mockEngine.Setup(x => x.ResolveTemplatePath(It.IsIn(new[] { "index" }))).Returns("path");
                         services.AddSingleton(mockEngine.Object);
                         var mockStoreService = new Mock<IStoreService>();
-                        mockStoreService.Setup(x => x.GetAllStoresAsync()).ReturnsAsync(new Store[] { new Store { Id = "Electronics", DefaultLanguage = new Model.Language("en-US") } });
+                        mockStoreService.Setup(x => x.GetAllStoresAsync()).ReturnsAsync(new Store[] { new Store { Id = "Electronics", DefaultLanguage = new Language("en-US") } });
                         services.AddSingleton(mockStoreService.Object);
 
                     })


### PR DESCRIPTION
I recently noticed a strange behavior of the `Money.TruncatedAmount` property. According to the description, it should return the value of `InternalAmount` truncated by `DecimalDigits`, but it sometimes doesn't do that. For example, if the `InternalAmount` is equal to `0.999` and `DecimalDigits` is equal to 2, I expect it to return `0.99`, but instead it returns `0.5`.
So, I've attempted to fix the `TruncatedAmount` property and add some tests for it. What do you think? Have I got the purpose of this property right?