### PR TITLE
#205 Migrate Storefront to NET Core 2.2.1:

### DIFF
--- a/VirtoCommerce.LiquidThemeEngine/VirtoCommerce.LiquidThemeEngine.csproj
+++ b/VirtoCommerce.LiquidThemeEngine/VirtoCommerce.LiquidThemeEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <Version>3.2.8</Version>
     <Description>The storefront implementation of the Virto Commerce platform.</Description>
     <Copyright>Copyright © 2011-2019 Virto Commerce - an enterprise Microsoft ecommerce platform ©. All rights reserved</Copyright>
@@ -23,7 +23,7 @@
     <PackageReference Include="LibSassHost.Native.linux-x64" Version="1.2.0" />
     <PackageReference Include="LibSassHost.Native.win-x64" Version="1.2.0" />
     <PackageReference Include="LibSassHost.Native.win-x86" Version="1.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.1" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-05" />
     <PackageReference Include="PagedList.Core" Version="1.17.4" />
   </ItemGroup>

--- a/VirtoCommerce.Storefront.Model/VirtoCommerce.Storefront.Model.csproj
+++ b/VirtoCommerce.Storefront.Model/VirtoCommerce.Storefront.Model.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <!--Need to include TargetLatestRuntimePatch, otherwise get following error about ASP NET Core restored version-->
+    <!--https://stackoverflow.com/questions/51642172/the-project-was-restored-using-microsoft-netcore-app-version-2-1-0-but-with-cur-->
+    <!--https://docs.microsoft.com/en-us/dotnet/core/deploying/runtime-patch-selection-->
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <Description>The storefront implementation of the Virto Commerce platform.</Description>
     <Copyright>Copyright © 2011-2019 Virto Commerce - an enterprise Microsoft ecommerce platform ©. All rights reserved</Copyright>
     <PackageLicenseUrl>https://virtocommerce.com/open-source-license</PackageLicenseUrl>
@@ -18,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.0.100" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.1" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-05" />
     <PackageReference Include="PagedList.Core" Version="1.17.4" />
   </ItemGroup>

--- a/VirtoCommerce.Storefront.Tests/VirtoCommerce.Storefront.Tests.csproj
+++ b/VirtoCommerce.Storefront.Tests/VirtoCommerce.Storefront.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />

--- a/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
+++ b/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <UserSecretsId>0cd403c4-2cd0-42b3-987a-02900f4a683e</UserSecretsId>
     <Company>Virto Commerce</Company>
@@ -42,8 +42,8 @@
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.8.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.Web" Version="2.8.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AutoRest.Common" Version="2.4.48" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.18" />
     <PackageReference Include="Microsoft.SyndicationFeed.ReaderWriter" Version="1.0.2" />

--- a/VirtoCommerce.Storefront/web.config
+++ b/VirtoCommerce.Storefront/web.config
@@ -9,7 +9,7 @@
     </modules>
     <handlers>
       <remove name="aspNetCore" />
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
     <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout">
       <environmentVariables />


### PR DESCRIPTION
- Microsoft.AspNetCore.App to 2.2.1 (VirtoCommerce.LiquidThemeEngine, VirtoCommerce.Storefront, VirtoCommerce.Storefront.Model)
- Microsoft.AspNetCore.Http.Extensions to 2.2.0 (VirtoCommerce.Storefront)
- Microsoft.AspNetCore.Mvc.Testing to 2.2.0 (VirtoCommerce.Storefront.Tests)
- Set TargetLatestRuntimePatch to VirtoCommerce.Storefront.Model.csproj to avoid version error: https://docs.microsoft.com/en-us/dotnet/core/deploying/runtime-patch-selection