### PR TITLE
removed Addresses field from user class

### DIFF
--- a/VirtoCommerce.Storefront.Model/Security/User.cs
+++ b/VirtoCommerce.Storefront.Model/Security/User.cs
@@ -1,9 +1,8 @@
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
+using Newtonsoft.Json;
 using VirtoCommerce.Storefront.Model.Common;
 using VirtoCommerce.Storefront.Model.Customer;
 using VirtoCommerce.Storefront.Model.Order;
@@ -149,6 +148,5 @@ namespace VirtoCommerce.Storefront.Model.Security
         public Address DefaultAddress => Contact?.DefaultAddress;
         public Address DefaultBillingAddress => Contact?.DefaultBillingAddress;
         public Address DefaultShippingAddress => Contact?.DefaultShippingAddress;
-        public IList<Address> Addresses => Contact?.Addresses;
     }
 }


### PR DESCRIPTION
User object is converted to json with BackwardCompatibilityJsonConverter. It merges fields. As a result, the object wich contains one item in Addresses collection is converted to json with two items in Addresses.