### PR TITLE
Storefront APIs should return only storefront models and avoid returning of AutoRest auto-generated models

### DIFF
--- a/VirtoCommerce.Storefront.Model/Order/ProcessPaymentResult.cs
+++ b/VirtoCommerce.Storefront.Model/Order/ProcessPaymentResult.cs
@@ -1,0 +1,19 @@
+namespace VirtoCommerce.Storefront.Model.Order
+{
+    public class ProcessPaymentResult
+    {
+        public PaymentMethod PaymentMethod { get; set; }
+
+        public string NewPaymentStatus { get; set; }
+
+        public string RedirectUrl { get; set; }
+
+        public string HtmlForm { get; set; }
+
+        public bool IsSuccess { get; set; }
+
+        public string Error { get; set; }
+
+        public string OuterId { get; set; }
+    }
+}

--- a/VirtoCommerce.Storefront/Controllers/Api/ApiOrderController.cs
+++ b/VirtoCommerce.Storefront/Controllers/Api/ApiOrderController.cs
@@ -104,7 +104,7 @@ namespace VirtoCommerce.Storefront.Controllers.Api
         // POST: storefrontapi/orders/{orderNumber}/payments/{paymentNumber}/process
         [HttpPost("{orderNumber}/payments/{paymentNumber}/process")]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult<ProcessOrderPaymentResult>> ProcessOrderPayment(string orderNumber, string paymentNumber, [FromBody][SwaggerOptional] orderModel.BankCardInfo bankCardInfo)
+        public async Task<ActionResult<ProcessOrderPaymentResult>> ProcessOrderPayment(string orderNumber, string paymentNumber, [FromBody][SwaggerOptional] BankCardInfo bankCardInfo)
         {
             //Need lock to prevent concurrent access to same order
             using (await AsyncLock.GetLockByKey(GetAsyncLockKey(orderNumber, WorkContext)).LockAsync())
@@ -115,11 +115,12 @@ namespace VirtoCommerce.Storefront.Controllers.Api
                 {
                     throw new StorefrontException("payment " + paymentNumber + " not found");
                 }
-                var processingResult = await _orderApi.ProcessOrderPaymentsAsync(orderDto.Id, paymentDto.Id, bankCardInfo);
+                var processingResult = await _orderApi.ProcessOrderPaymentsAsync(orderDto.Id, paymentDto.Id, bankCardInfo.ToBankCardInfoDto());
+                var order = orderDto.ToCustomerOrder(WorkContext.AllCurrencies, WorkContext.CurrentLanguage);
                 return new ProcessOrderPaymentResult
                 {
-                    OrderProcessingResult = processingResult,
-                    PaymentMethod = paymentDto.PaymentMethod
+                    OrderProcessingResult = processingResult.ToProcessPaymentResult(order),
+                    PaymentMethod = paymentDto.PaymentMethod.ToPaymentMethod(order)
                 };
             }
         }
@@ -127,7 +128,7 @@ namespace VirtoCommerce.Storefront.Controllers.Api
         // POST: storefrontapi/orders/{orderNumber}/payments
         [HttpPost("{orderNumber}/payments")]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult<orderModel.PaymentIn>> AddOrUpdateOrderPayment(string orderNumber, [FromBody] PaymentIn payment)
+        public async Task<ActionResult<PaymentIn>> AddOrUpdateOrderPayment(string orderNumber, [FromBody] PaymentIn payment)
         {
             if (payment.Sum.Amount == 0)
             {
@@ -159,7 +160,7 @@ namespace VirtoCommerce.Storefront.Controllers.Api
                     //Because we don't know the new payment id we need to get latest payment with same gateway code
                     paymentDto = orderDto.InPayments.Where(x => x.GatewayCode.EqualsInvariant(payment.GatewayCode)).OrderByDescending(x => x.CreatedDate).FirstOrDefault();
                 }
-                return paymentDto;
+                return paymentDto.ToOrderInPayment(WorkContext.AllCurrencies, WorkContext.CurrentLanguage);
             }
 
         }

--- a/VirtoCommerce.Storefront/Domain/Order/OrderConverter.cs
+++ b/VirtoCommerce.Storefront/Domain/Order/OrderConverter.cs
@@ -478,6 +478,11 @@ namespace VirtoCommerce.Storefront.Domain
             return result;
         }
 
+        public static PaymentMethod ToPaymentMethod(this orderDto.PaymentMethod paymentMethodDto, CustomerOrder order)
+        {
+            return paymentMethodDto.JsonConvert<storeDto.PaymentMethod>().ToPaymentMethod(order);
+        }
+
         public static PaymentMethod ToPaymentMethod(this storeDto.PaymentMethod paymentMethodDto, CustomerOrder order)
         {
             var retVal = new PaymentMethod(order.Currency)
@@ -510,6 +515,20 @@ namespace VirtoCommerce.Storefront.Domain
             }
 
             return retVal;
+        }
+
+        public static ProcessPaymentResult ToProcessPaymentResult(this orderDto.ProcessPaymentResult processPaymentResultDto, CustomerOrder order)
+        {
+            return new ProcessPaymentResult()
+            {
+                Error = processPaymentResultDto.Error,
+                HtmlForm = processPaymentResultDto.HtmlForm,
+                IsSuccess = processPaymentResultDto.IsSuccess ?? false,
+                NewPaymentStatus = processPaymentResultDto.NewPaymentStatus,
+                OuterId = processPaymentResultDto.OuterId,
+                PaymentMethod = processPaymentResultDto.PaymentMethod.ToPaymentMethod(order),
+                RedirectUrl = processPaymentResultDto.RedirectUrl
+            };
         }
 
         public static TaxDetail ToTaxDetail(this storeDto.TaxDetail dto, Currency currency)

--- a/VirtoCommerce.Storefront/Domain/Order/OrderCreatedInfo.cs
+++ b/VirtoCommerce.Storefront/Domain/Order/OrderCreatedInfo.cs
@@ -1,4 +1,5 @@
-using VirtoCommerce.Storefront.AutoRestClients.OrdersModuleApi.Models;
+using VirtoCommerce.Storefront.Model;
+using VirtoCommerce.Storefront.Model.Order;
 
 namespace VirtoCommerce.Storefront.Domain
 {

--- a/VirtoCommerce.Storefront/Domain/Order/ProcessOrderPaymentResult.cs
+++ b/VirtoCommerce.Storefront/Domain/Order/ProcessOrderPaymentResult.cs
@@ -1,4 +1,5 @@
-using VirtoCommerce.Storefront.AutoRestClients.OrdersModuleApi.Models;
+using VirtoCommerce.Storefront.Model;
+using VirtoCommerce.Storefront.Model.Order;
 
 namespace VirtoCommerce.Storefront.Domain
 {


### PR DESCRIPTION
**Warning:** this PR will cause breaking changes. We need to first check and fix if needed problems in our themes.

Currently some storefront APIs return AutoRest models directly without converting into storefront models. It may cause some discomfort especially when working with models generated by AutoRest or SwaggerCodegen in typescript.

Also, removal of AutoRest models will significantly reduce size of OpenAPI document and number of generated models:

| Parameter | Before | After |
| --- | --- | --- |
| Number of models | 159 | 106 |
| Size of docs.json | 167 KB | 120 KB |