### PR TITLE
Generate friendly names storefront models in swagger

### DIFF
--- a/VirtoCommerce.Storefront.Model/Cart/LineItem.cs
+++ b/VirtoCommerce.Storefront.Model/Cart/LineItem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using VirtoCommerce.Storefront.Infrastructure.Swagger;
 using VirtoCommerce.Storefront.Model.Cart.Services;
 using VirtoCommerce.Storefront.Model.Cart.ValidationErrors;
 using VirtoCommerce.Storefront.Model.Catalog;
@@ -10,6 +11,7 @@ using VirtoCommerce.Storefront.Model.Subscriptions;
 
 namespace VirtoCommerce.Storefront.Model.Cart
 {
+    [SwaggerSchemaId("CartLineItem")]
     public partial class LineItem : Entity, IDiscountable, IValidatable, ITaxable, ICloneable
     {
         public LineItem(Currency currency, Language language)

--- a/VirtoCommerce.Storefront.Model/Cart/Shipment.cs
+++ b/VirtoCommerce.Storefront.Model/Cart/Shipment.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using VirtoCommerce.Storefront.Infrastructure.Swagger;
 using VirtoCommerce.Storefront.Model.Cart.Services;
 using VirtoCommerce.Storefront.Model.Cart.ValidationErrors;
 using VirtoCommerce.Storefront.Model.Common;
@@ -7,6 +8,7 @@ using VirtoCommerce.Storefront.Model.Marketing;
 
 namespace VirtoCommerce.Storefront.Model.Cart
 {
+    [SwaggerSchemaId("CartShipment")]
     public partial class Shipment : Entity, IDiscountable, IValidatable, ITaxable
     {
         public Shipment()

--- a/VirtoCommerce.Storefront.Model/Order/LineItem.cs
+++ b/VirtoCommerce.Storefront.Model/Order/LineItem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using VirtoCommerce.Storefront.Infrastructure.Swagger;
 using VirtoCommerce.Storefront.Model.Common;
 using VirtoCommerce.Storefront.Model.Marketing;
 
@@ -8,6 +9,7 @@ namespace VirtoCommerce.Storefront.Model.Order
     /// <summary>
     /// Represents order line item
     /// </summary>
+    [SwaggerSchemaId("OrderLineItem")]
     public partial class LineItem
     {
         public LineItem(Currency currency)

--- a/VirtoCommerce.Storefront.Model/Order/ProcessPaymentResult.cs
+++ b/VirtoCommerce.Storefront.Model/Order/ProcessPaymentResult.cs
@@ -1,0 +1,19 @@
+namespace VirtoCommerce.Storefront.Model.Order
+{
+    public class ProcessPaymentResult
+    {
+        public PaymentMethod PaymentMethod { get; set; }
+
+        public string NewPaymentStatus { get; set; }
+
+        public string RedirectUrl { get; set; }
+
+        public string HtmlForm { get; set; }
+
+        public bool IsSuccess { get; set; }
+
+        public string Error { get; set; }
+
+        public string OuterId { get; set; }
+    }
+}

--- a/VirtoCommerce.Storefront.Model/Order/Shipment.cs
+++ b/VirtoCommerce.Storefront.Model/Order/Shipment.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using VirtoCommerce.Storefront.Infrastructure.Swagger;
 using VirtoCommerce.Storefront.Model.Common;
 using VirtoCommerce.Storefront.Model.Marketing;
 
@@ -8,6 +9,7 @@ namespace VirtoCommerce.Storefront.Model.Order
     /// <summary>
     /// Represents order shipment
     /// </summary>
+    [SwaggerSchemaId("OrderShipment")]
     public partial class Shipment
     {
         public Shipment(Currency currency)

--- a/VirtoCommerce.Storefront.Model/SwaggerCustomSchemaIdAttribute.cs
+++ b/VirtoCommerce.Storefront.Model/SwaggerCustomSchemaIdAttribute.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace VirtoCommerce.Storefront.Infrastructure.Swagger
+{
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public class SwaggerSchemaIdAttribute : Attribute
+    {
+        public string Id { get; private set; }
+
+        public SwaggerSchemaIdAttribute(string id)
+        {
+            Id = id;
+        }
+    }
+}

--- a/VirtoCommerce.Storefront/Controllers/Api/ApiOrderController.cs
+++ b/VirtoCommerce.Storefront/Controllers/Api/ApiOrderController.cs
@@ -104,7 +104,7 @@ namespace VirtoCommerce.Storefront.Controllers.Api
         // POST: storefrontapi/orders/{orderNumber}/payments/{paymentNumber}/process
         [HttpPost("{orderNumber}/payments/{paymentNumber}/process")]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult<ProcessOrderPaymentResult>> ProcessOrderPayment(string orderNumber, string paymentNumber, [FromBody][SwaggerOptional] orderModel.BankCardInfo bankCardInfo)
+        public async Task<ActionResult<ProcessOrderPaymentResult>> ProcessOrderPayment(string orderNumber, string paymentNumber, [FromBody][SwaggerOptional] BankCardInfo bankCardInfo)
         {
             //Need lock to prevent concurrent access to same order
             using (await AsyncLock.GetLockByKey(GetAsyncLockKey(orderNumber, WorkContext)).LockAsync())
@@ -115,11 +115,12 @@ namespace VirtoCommerce.Storefront.Controllers.Api
                 {
                     throw new StorefrontException("payment " + paymentNumber + " not found");
                 }
-                var processingResult = await _orderApi.ProcessOrderPaymentsAsync(orderDto.Id, paymentDto.Id, bankCardInfo);
+                var processingResult = await _orderApi.ProcessOrderPaymentsAsync(orderDto.Id, paymentDto.Id, bankCardInfo.ToBankCardInfoDto());
+                var order = orderDto.ToCustomerOrder(WorkContext.AllCurrencies, WorkContext.CurrentLanguage);
                 return new ProcessOrderPaymentResult
                 {
-                    OrderProcessingResult = processingResult,
-                    PaymentMethod = paymentDto.PaymentMethod
+                    OrderProcessingResult = processingResult.ToProcessPaymentResult(order),
+                    PaymentMethod = paymentDto.PaymentMethod.ToPaymentMethod(order)
                 };
             }
         }
@@ -127,7 +128,7 @@ namespace VirtoCommerce.Storefront.Controllers.Api
         // POST: storefrontapi/orders/{orderNumber}/payments
         [HttpPost("{orderNumber}/payments")]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult<orderModel.PaymentIn>> AddOrUpdateOrderPayment(string orderNumber, [FromBody] PaymentIn payment)
+        public async Task<ActionResult<PaymentIn>> AddOrUpdateOrderPayment(string orderNumber, [FromBody] PaymentIn payment)
         {
             if (payment.Sum.Amount == 0)
             {
@@ -159,7 +160,7 @@ namespace VirtoCommerce.Storefront.Controllers.Api
                     //Because we don't know the new payment id we need to get latest payment with same gateway code
                     paymentDto = orderDto.InPayments.Where(x => x.GatewayCode.EqualsInvariant(payment.GatewayCode)).OrderByDescending(x => x.CreatedDate).FirstOrDefault();
                 }
-                return paymentDto;
+                return paymentDto.ToOrderInPayment(WorkContext.AllCurrencies, WorkContext.CurrentLanguage);
             }
 
         }

--- a/VirtoCommerce.Storefront/Domain/Order/OrderConverter.cs
+++ b/VirtoCommerce.Storefront/Domain/Order/OrderConverter.cs
@@ -478,6 +478,11 @@ namespace VirtoCommerce.Storefront.Domain
             return result;
         }
 
+        public static PaymentMethod ToPaymentMethod(this orderDto.PaymentMethod paymentMethodDto, CustomerOrder order)
+        {
+            return paymentMethodDto.JsonConvert<storeDto.PaymentMethod>().ToPaymentMethod(order);
+        }
+
         public static PaymentMethod ToPaymentMethod(this storeDto.PaymentMethod paymentMethodDto, CustomerOrder order)
         {
             var retVal = new PaymentMethod(order.Currency)
@@ -510,6 +515,20 @@ namespace VirtoCommerce.Storefront.Domain
             }
 
             return retVal;
+        }
+
+        public static ProcessPaymentResult ToProcessPaymentResult(this orderDto.ProcessPaymentResult processPaymentResultDto, CustomerOrder order)
+        {
+            return new ProcessPaymentResult()
+            {
+                Error = processPaymentResultDto.Error,
+                HtmlForm = processPaymentResultDto.HtmlForm,
+                IsSuccess = processPaymentResultDto.IsSuccess ?? false,
+                NewPaymentStatus = processPaymentResultDto.NewPaymentStatus,
+                OuterId = processPaymentResultDto.OuterId,
+                PaymentMethod = processPaymentResultDto.PaymentMethod.ToPaymentMethod(order),
+                RedirectUrl = processPaymentResultDto.RedirectUrl
+            };
         }
 
         public static TaxDetail ToTaxDetail(this storeDto.TaxDetail dto, Currency currency)

--- a/VirtoCommerce.Storefront/Domain/Order/OrderCreatedInfo.cs
+++ b/VirtoCommerce.Storefront/Domain/Order/OrderCreatedInfo.cs
@@ -1,4 +1,5 @@
-using VirtoCommerce.Storefront.AutoRestClients.OrdersModuleApi.Models;
+using VirtoCommerce.Storefront.Model;
+using VirtoCommerce.Storefront.Model.Order;
 
 namespace VirtoCommerce.Storefront.Domain
 {

--- a/VirtoCommerce.Storefront/Domain/Order/ProcessOrderPaymentResult.cs
+++ b/VirtoCommerce.Storefront/Domain/Order/ProcessOrderPaymentResult.cs
@@ -1,4 +1,5 @@
-using VirtoCommerce.Storefront.AutoRestClients.OrdersModuleApi.Models;
+using VirtoCommerce.Storefront.Model;
+using VirtoCommerce.Storefront.Model.Order;
 
 namespace VirtoCommerce.Storefront.Domain
 {

--- a/VirtoCommerce.Storefront/Startup.cs
+++ b/VirtoCommerce.Storefront/Startup.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.WebEncoders;
 using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
 using VirtoCommerce.LiquidThemeEngine;
 using VirtoCommerce.Storefront.Binders;
 using VirtoCommerce.Storefront.Caching;
@@ -324,8 +325,7 @@ namespace VirtoCommerce.Storefront
                 c.ParameterFilter<EnumDefaultValueParameterFilter>();
 
                 // To avoid errors with repeating type names
-                c.CustomSchemaIds(type => type.ToString()
-                );
+                c.CustomSchemaIds(type => (Attribute.GetCustomAttribute(type, typeof(SwaggerSchemaIdAttribute)) as SwaggerSchemaIdAttribute)?.Id ?? type.FriendlyId());
             });
 
             services.AddResponseCompression();


### PR DESCRIPTION
Instead of using full qualified type names like `VirtoCommerce.Storefront.Model.Catalog.Product` we may want to use friendly names like just `Product` in swagger schema. Otherwise some generation tools like swagger codegen will generate very long not useful class names for models (it's by design) like `virtoCommerceStorefrontModelCatalogProduct`.

Note: this PR depend on #253