### PR TITLE
store & language routing parameters marked as optional

### DIFF
--- a/VirtoCommerce.Storefront/Infrastructure/Swagger/OptionalParametersFilter.cs
+++ b/VirtoCommerce.Storefront/Infrastructure/Swagger/OptionalParametersFilter.cs
@@ -12,8 +12,9 @@ namespace VirtoCommerce.Storefront.Infrastructure.Swagger
             if (operation.Parameters?.Any() == true)
             {
                 var optionalParameters = context.ApiDescription.ParameterDescriptions
-                    .Where(x => x.ParameterDescriptor != null &&
-                        ((ControllerParameterDescriptor)x.ParameterDescriptor).ParameterInfo.CustomAttributes.Any(attr => attr.AttributeType == typeof(SwaggerOptionalAttribute)))
+                    .Where(x => !x.IsRequired || x.ParameterDescriptor != null &&
+                                ((ControllerParameterDescriptor)x.ParameterDescriptor).ParameterInfo.CustomAttributes
+                                .Any(attr => attr.AttributeType == typeof(SwaggerOptionalAttribute)))
                     .ToList();
 
                 foreach (var apiParameter in optionalParameters)

--- a/VirtoCommerce.Storefront/Routing/StorefrontRoute.cs
+++ b/VirtoCommerce.Storefront/Routing/StorefrontRoute.cs
@@ -8,7 +8,7 @@ namespace VirtoCommerce.Storefront.Routing
 {
     public class StorefrontRoute : Route
     {
-        private const string _regexp = "{store}/{language:regex([a-zA-Z]{{2}}-[a-zA-Z]{{2}})}/";
+        private const string _regexp = "{store?}/{language:regex([a-zA-Z]{{2}}-[a-zA-Z]{{2}})?}/";
         public StorefrontRoute(IRouter target, string routeTemplate, IInlineConstraintResolver inlineConstraintResolver)
             : this(target, routeTemplate, null, null, null, inlineConstraintResolver)
         {

--- a/VirtoCommerce.Storefront/Routing/StorefrontRouteAttribute.cs
+++ b/VirtoCommerce.Storefront/Routing/StorefrontRouteAttribute.cs
@@ -6,7 +6,7 @@ namespace VirtoCommerce.Storefront.Infrastructure
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     public class StorefrontRouteAttribute : Attribute, IRouteTemplateProvider
     {
-        private const string _regexp = "{store}/{language:regex([[a-zA-Z]]{{2}}-[[a-zA-Z]]{{2}})}/";
+        private const string _regexp = "{store?}/{language:regex([[a-zA-Z]]{{2}}-[[a-zA-Z]]{{2}})?}/";
 
         public StorefrontRouteAttribute()
             : this(string.Empty)


### PR DESCRIPTION
These optional routing parameters should use ASP.NET routing convention (i.e. `/{store?}/{language?}`) and be marked as optional in swagger