### PR TITLE
Bump Microsoft.Extensions.Logging.AzureAppServices version to 2.2.5

### DIFF
--- a/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
+++ b/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
@@ -50,7 +50,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AutoRest.Common" Version="2.4.48" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.2.5" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.18" />
     <PackageReference Include="Microsoft.SyndicationFeed.ReaderWriter" Version="1.0.2" />
     <PackageReference Include="MimeTypes" Version="1.1.0">


### PR DESCRIPTION
Storefront v4 fails in Azure with 

> HTTP Error 500.30 - ANCM In-Process Start Failure

 if you have **ASP.NET Core Logging Extensions 2.2.0** installed. This upgrade resolves the problem