### PR TITLE
Ignore ARR Affinity Cookie

### DIFF
--- a/VirtoCommerce.Storefront/DependencyInjection/ServiceCollectionExtension.cs
+++ b/VirtoCommerce.Storefront/DependencyInjection/ServiceCollectionExtension.cs
@@ -66,7 +66,7 @@ namespace VirtoCommerce.Storefront.DependencyInjection
                       httpClient.BaseAddress = platformEndpointOptions.Url;
                       httpClient.Timeout = platformEndpointOptions.RequestTimeout;
                   })
-                   .ConfigurePrimaryHttpMessageHandler(x => new HttpClientHandler() { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate })
+                   .ConfigurePrimaryHttpMessageHandler(x => new HttpClientHandler() { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate, UseCookies = false })
                    .AddHttpMessageHandler(sp => sp.GetService<AuthenticationHandlerFactory>().CreateAuthHandler());
 
 


### PR DESCRIPTION
Turn Off Cookies. ARR Affinity Cookie was cached the global level on the first request and storefront worked with a single instance of the platform although you set up multiple instances of the platform.