### PR TITLE
Vp 1268 Make category properties available in liquid handlers.

### DIFF
--- a/VirtoCommerce.Storefront.Model/Catalog/Category.cs
+++ b/VirtoCommerce.Storefront.Model/Catalog/Category.cs
@@ -5,12 +5,12 @@ using VirtoCommerce.Storefront.Model.Common;
 
 namespace VirtoCommerce.Storefront.Model.Catalog
 {
-    public partial class Category : Entity, IHasProperties, IAccessibleByIndexKey
+    public partial class Category : Entity, IAccessibleByIndexKey
     {
         public Category()
         {
             Images = new List<Image>();
-            Properties = new List<CatalogProperty>();
+            Properties = MutablePagedList<CatalogProperty>.Empty;
         }
 
         public string CatalogId { get; set; }
@@ -72,7 +72,7 @@ namespace VirtoCommerce.Storefront.Model.Catalog
         }
 
         #region IHasProperties Members
-        public IList<CatalogProperty> Properties { get; set; }
+        public IMutablePagedList<CatalogProperty> Properties { get; set; }
         #endregion
 
         public string Handle => SeoInfo?.Slug ?? Id;

--- a/VirtoCommerce.Storefront.Model/Catalog/Category.cs
+++ b/VirtoCommerce.Storefront.Model/Catalog/Category.cs
@@ -71,10 +71,7 @@ namespace VirtoCommerce.Storefront.Model.Catalog
             return SeoPath ?? base.ToString();
         }
 
-        #region IHasProperties Members
         public IMutablePagedList<CatalogProperty> Properties { get; set; }
-        #endregion
-
         public string Handle => SeoInfo?.Slug ?? Id;
         public string IndexKey => Handle;
     }

--- a/VirtoCommerce.Storefront/Domain/Catalog/CatalogConverter.cs
+++ b/VirtoCommerce.Storefront/Domain/Catalog/CatalogConverter.cs
@@ -270,10 +270,9 @@ namespace VirtoCommerce.Storefront.Domain
 
             if (categoryDto.Properties != null)
             {
-                result.Properties = categoryDto.Properties
+                result.Properties = new MutablePagedList<CatalogProperty>(categoryDto.Properties
                     .Where(x => string.Equals(x.Type, "Category", StringComparison.OrdinalIgnoreCase))
-                    .Select(p => ToProperty(p, currentLanguage))
-                    .ToList();
+                    .Select(p => ToProperty(p, currentLanguage)));
             }
 
             return result;


### PR DESCRIPTION
Change the type of category.properties from IList to IMutablePageList. Eventually, we can use dot notation in liquid template like this '{{ collection.properties.bottomSection.value }} ' to getting property value.