### PR TITLE
Added support of @import directives in sass

### DIFF
--- a/VirtoCommerce.LiquidThemeEngine/ISassFileManager.cs
+++ b/VirtoCommerce.LiquidThemeEngine/ISassFileManager.cs
@@ -4,6 +4,6 @@ namespace VirtoCommerce.LiquidThemeEngine
 {
     public interface ISassFileManager: IFileManager
     {
-        string CurrentPath { get; set; }
+        string CurrentDirectory { get; set; }
     }
 }

--- a/VirtoCommerce.LiquidThemeEngine/ISassFileManager.cs
+++ b/VirtoCommerce.LiquidThemeEngine/ISassFileManager.cs
@@ -1,0 +1,9 @@
+using LibSassHost;
+
+namespace VirtoCommerce.LiquidThemeEngine
+{
+    public interface ISassFileManager: IFileManager
+    {
+        string CurrentPath { get; set; }
+    }
+}

--- a/VirtoCommerce.LiquidThemeEngine/SassFileManager.cs
+++ b/VirtoCommerce.LiquidThemeEngine/SassFileManager.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using LibSassHost;
+using VirtoCommerce.Storefront.Model;
+using VirtoCommerce.Storefront.Model.Common;
+using VirtoCommerce.Storefront.Model.StaticContent;
+
+namespace VirtoCommerce.LiquidThemeEngine
+{
+    public class SassFileManager: ISassFileManager
+    {
+        private readonly IContentBlobProvider _contentBlobProvider;
+
+        public bool SupportsConversionToAbsolutePath { get; } = false;
+
+        public string CurrentPath { get; set; }
+
+        public SassFileManager(IContentBlobProvider contentBlobProvider)
+        {
+            _contentBlobProvider = contentBlobProvider;
+        }
+
+        public string GetCurrentDirectory()
+        {
+            return Path.GetDirectoryName(CurrentPath);
+        }
+
+        public bool FileExists(string path)
+        {
+            return _contentBlobProvider.PathExists(path);
+        }
+
+        public bool IsAbsolutePath(string path)
+        {
+            return false;
+        }
+
+        public string ToAbsolutePath(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string ReadFile(string path)
+        {
+            return _contentBlobProvider.OpenRead(path).ReadToString();
+        }
+    }
+}

--- a/VirtoCommerce.LiquidThemeEngine/SassFileManager.cs
+++ b/VirtoCommerce.LiquidThemeEngine/SassFileManager.cs
@@ -13,26 +13,28 @@ namespace VirtoCommerce.LiquidThemeEngine
 
         public bool SupportsConversionToAbsolutePath { get; } = false;
 
-        public string CurrentPath { get; set; }
+        public string CurrentDirectory { get; set; }
 
         public SassFileManager(IContentBlobProvider contentBlobProvider)
         {
             _contentBlobProvider = contentBlobProvider;
         }
 
-        public string GetCurrentDirectory()
-        {
-            return Path.GetDirectoryName(CurrentPath);
-        }
+        public string GetCurrentDirectory() => CurrentDirectory;
 
         public bool FileExists(string path)
         {
+            // Workaround for directories
+            if (string.IsNullOrEmpty(Path.GetExtension(path)))
+            {
+                return false;
+            }
             return _contentBlobProvider.PathExists(path);
         }
 
         public bool IsAbsolutePath(string path)
         {
-            return false;
+            return =Path.GetDirectoryName(path).StartsWith(CurrentDirectory);
         }
 
         public string ToAbsolutePath(string path)

--- a/VirtoCommerce.LiquidThemeEngine/SassFileManager.cs
+++ b/VirtoCommerce.LiquidThemeEngine/SassFileManager.cs
@@ -34,7 +34,7 @@ namespace VirtoCommerce.LiquidThemeEngine
 
         public bool IsAbsolutePath(string path)
         {
-            return =Path.GetDirectoryName(path).StartsWith(CurrentDirectory);
+            return Path.GetDirectoryName(path).StartsWith(CurrentDirectory);
         }
 
         public string ToAbsolutePath(string path)

--- a/VirtoCommerce.LiquidThemeEngine/ShopifyLiquidThemeEngine.cs
+++ b/VirtoCommerce.LiquidThemeEngine/ShopifyLiquidThemeEngine.cs
@@ -46,17 +46,19 @@ namespace VirtoCommerce.LiquidThemeEngine
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IStorefrontMemoryCache _memoryCache;
         private readonly IContentBlobProvider _themeBlobProvider;
+        private readonly ISassFileManager _sassFileManager;
 
-        public ShopifyLiquidThemeEngine(IStorefrontMemoryCache memoryCache, IWorkContextAccessor workContextAccessor,
-                                        IHttpContextAccessor httpContextAccessor,
-                                        IStorefrontUrlBuilder storeFrontUrlBuilder, IContentBlobProvider contentBlobProvder, IOptions<LiquidThemeEngineOptions> options)
+        public ShopifyLiquidThemeEngine(IStorefrontMemoryCache memoryCache, IWorkContextAccessor workContextAccessor, IHttpContextAccessor httpContextAccessor,
+                                        IStorefrontUrlBuilder storeFrontUrlBuilder, IContentBlobProvider contentBlobProvider, ISassFileManager sassFileManager, IOptions<LiquidThemeEngineOptions> options)
         {
             _workContextAccessor = workContextAccessor;
             _httpContextAccessor = httpContextAccessor;
             UrlBuilder = storeFrontUrlBuilder;
             _options = options.Value;
             _memoryCache = memoryCache;
-            _themeBlobProvider = contentBlobProvder;
+            _themeBlobProvider = contentBlobProvider;
+            _sassFileManager = sassFileManager;
+            SassCompiler.FileManager = sassFileManager;
         }
 
         /// <summary>
@@ -184,6 +186,7 @@ namespace VirtoCommerce.LiquidThemeEngine
                 try
                 {
                     //handle scss resources
+                    _sassFileManager.CurrentPath = filePath;
                     var result = SassCompiler.Compile(content);
                     content = result.CompiledContent;
 

--- a/VirtoCommerce.LiquidThemeEngine/ShopifyLiquidThemeEngine.cs
+++ b/VirtoCommerce.LiquidThemeEngine/ShopifyLiquidThemeEngine.cs
@@ -186,7 +186,7 @@ namespace VirtoCommerce.LiquidThemeEngine
                 try
                 {
                     //handle scss resources
-                    _sassFileManager.CurrentPath = filePath;
+                    _sassFileManager.CurrentDirectory = Path.GetDirectoryName(filePath);
                     var result = SassCompiler.Compile(content);
                     content = result.CompiledContent;
 

--- a/VirtoCommerce.Storefront/DependencyInjection/ServiceCollectionExtension.cs
+++ b/VirtoCommerce.Storefront/DependencyInjection/ServiceCollectionExtension.cs
@@ -179,7 +179,8 @@ namespace VirtoCommerce.Storefront.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(services));
             }
-
+            
+            services.AddSingleton<ISassFileManager, SassFileManager>();
             services.AddSingleton<ILiquidThemeEngine, ShopifyLiquidThemeEngine>();
             services.AddSingleton<ILiquidViewEngine, LiquidThemedViewEngine>();
             if (setupAction != null)


### PR DESCRIPTION
About workaround with directories. SASS/SCSS allow to make import like this:
```scss
@import 'mixins';
```
If you have both `mixins` folder and `mixins.scss`, compiler will throw an exception because it can't determine which one use.