### PR TITLE
VP-2011: Use available inventory if nothing in default ffc

### DIFF
--- a/VirtoCommerce.Storefront.Tests/Inventory/InventoryTests.cs
+++ b/VirtoCommerce.Storefront.Tests/Inventory/InventoryTests.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Rest;
+using Moq;
+using VirtoCommerce.Storefront.AutoRestClients.InventoryModuleApi;
+using VirtoCommerce.Storefront.AutoRestClients.InventoryModuleApi.Models;
+using VirtoCommerce.Storefront.Caching;
+using VirtoCommerce.Storefront.Domain;
+using VirtoCommerce.Storefront.Infrastructure;
+using VirtoCommerce.Storefront.Model;
+using VirtoCommerce.Storefront.Model.Catalog;
+using VirtoCommerce.Storefront.Model.Stores;
+using Xunit;
+
+namespace VirtoCommerce.Storefront.Tests.Inventory
+{
+    public class InventoryTests
+    {
+        [Fact]
+        // https://virtocommerce.atlassian.net/browse/VP-2011
+        public async Task EvaluateProductInventories_NoDefaultFFCEntry_InventoryInfoFilled()
+        {
+            // Arrage
+            var products = new[]
+            {
+                new Product() { Id = "Product1" }
+            };
+            var workContext = new WorkContext()
+            {
+                CurrentStore = new Store()
+                {
+                    DefaultFulfillmentCenterId = "FFC_Default",
+                    AvailFulfillmentCenterIds = new[] { "FFC_Available_1", "FFC_Available_2" },
+                },
+            };
+            var availableInventories = new List<InventoryInfo>()
+            {
+                new InventoryInfo() { ProductId = "Product1", FulfillmentCenterId = "FFC_Available_1", InStockQuantity = 3 },
+                new InventoryInfo() { ProductId = "Product1", FulfillmentCenterId = "FFC_Available_2", InStockQuantity = 5 },
+            };
+            var inventoryService = CreateInventoryService(availableInventories);
+
+            // Act
+            await inventoryService.EvaluateProductInventoriesAsync(products, workContext);
+
+            // Assert
+            Assert.NotNull(products[0].Inventory);
+            Assert.Equal("FFC_Available_2", products[0].Inventory.FulfillmentCenterId);
+            Assert.Equal("Product1", products[0].Inventory.ProductId);
+            Assert.Equal(5, products[0].Inventory.InStockQuantity);
+
+            Assert.NotNull(products[0].InventoryAll);
+            Assert.Equal(2, products[0].InventoryAll.Count);
+            Assert.Equal("FFC_Available_1", products[0].InventoryAll[0].FulfillmentCenterId);
+            Assert.Equal("Product1", products[0].InventoryAll[0].ProductId);
+            Assert.Equal(3, products[0].InventoryAll[0].InStockQuantity);
+            Assert.Equal("FFC_Available_2", products[0].InventoryAll[1].FulfillmentCenterId);
+            Assert.Equal("Product1", products[0].InventoryAll[1].ProductId);
+            Assert.Equal(5, products[0].InventoryAll[1].InStockQuantity);
+        }
+
+        private static InventoryService CreateInventoryService(IEnumerable<InventoryInfo> allInventoryInfos)
+        {
+            var inventoryModuleStub = new Mock<IInventoryModule>();
+
+            inventoryModuleStub.Setup(x => x.GetProductsInventoriesByPlentyIdsWithHttpMessagesAsync(It.IsAny<IList<string>>(), null, It.IsAny<CancellationToken>()))
+                .Returns<IList<string>, Dictionary<string, List<string>>, CancellationToken>((ids, customHeaders, cancellationToken) =>
+                    Task.FromResult(
+                        new HttpOperationResponse<IList<InventoryInfo>>()
+                        {
+                            Body = allInventoryInfos.Where(inventoryInfo => ids.Any(id => id == inventoryInfo.ProductId)).ToList(),
+                        }));
+
+            var storefrontMemoryCache = CreateStorefrontMemoryCache();
+
+            var apiChangesWatcherStub = new Mock<IApiChangesWatcher>();
+            var result = new InventoryService(inventoryModuleStub.Object, storefrontMemoryCache, apiChangesWatcherStub.Object);
+
+            return result;
+        }
+
+        private static StorefrontMemoryCache CreateStorefrontMemoryCache()
+        {
+            var services = new ServiceCollection();
+
+            services.AddMemoryCache();
+
+            var serviceProvider = services.BuildServiceProvider();
+            var memoryCache = serviceProvider.GetService<IMemoryCache>();
+
+            var loggerFactoryStub = new Mock<ILoggerFactory>();
+            var workContextAccessorStub = new Mock<IWorkContextAccessor>();
+            var result = new StorefrontMemoryCache(memoryCache, Options.Create(new StorefrontOptions()), loggerFactoryStub.Object, workContextAccessorStub.Object);
+
+            return result;
+        }
+    }
+}

--- a/VirtoCommerce.Storefront/Domain/Inventory/InventoryService.cs
+++ b/VirtoCommerce.Storefront/Domain/Inventory/InventoryService.cs
@@ -51,9 +51,11 @@ namespace VirtoCommerce.Storefront.Domain
                 //TODO: Change these conditions to DDD specification
                 item.InventoryAll = inventories.Where(x => x.ProductId == item.Id).Select(x => x.ToInventory()).Where(x => availFullfilmentCentersIds.Contains(x.FulfillmentCenterId)).ToList();
                 item.Inventory = item.InventoryAll.OrderByDescending(x => Math.Max(0, (x.InStockQuantity ?? 0L) - (x.ReservedQuantity ?? 0L))).FirstOrDefault();
+
                 if (workContext.CurrentStore.DefaultFulfillmentCenterId != null)
                 {
-                    item.Inventory = item.InventoryAll.FirstOrDefault(x => x.FulfillmentCenterId == workContext.CurrentStore.DefaultFulfillmentCenterId);
+                    item.Inventory = item.InventoryAll.FirstOrDefault(x => x.FulfillmentCenterId == workContext.CurrentStore.DefaultFulfillmentCenterId)
+                        ?? item.Inventory;
                 }
             }
         }


### PR DESCRIPTION
If item do not have record for inventory in default ffc, other available inventories could be used for inventory checking;