### PR TITLE
VP-2407: Prevent organization registration with duplicated userName or email

### DIFF
--- a/VirtoCommerce.Storefront/Controllers/Api/ApiAccountController.cs
+++ b/VirtoCommerce.Storefront/Controllers/Api/ApiAccountController.cs
@@ -110,7 +110,12 @@ namespace VirtoCommerce.Storefront.Controllers.Api
 
             if (ModelState.IsValid)
             {
-                var user = await _userManager.FindByNameAsync(orgRegistration.UserName);
+                var user = await _userManager.FindByEmailAsync(orgRegistration.Email);
+                if (user != null)
+                {
+                    return IdentityResult.Failed(new IdentityError[] { new IdentityError() { Description = $"Email '{orgRegistration.Email}' is already taken." } });
+                }
+                user = await _userManager.FindByNameAsync(orgRegistration.UserName);
                 if (user == null)
                 {
                     var organization = orgRegistration.ToOrganization();
@@ -134,7 +139,7 @@ namespace VirtoCommerce.Storefront.Controllers.Api
                 }
                 else
                 {
-                    result = IdentityResult.Failed(new IdentityError[] { new IdentityError() { Description = $"User name '{orgRegistration.UserName}' is already taken." } });
+                    return IdentityResult.Failed(new IdentityError[] { new IdentityError() { Description = $"User name '{orgRegistration.UserName}' is already taken." } });
                 }
             }
             else

--- a/VirtoCommerce.Storefront/Controllers/Api/ApiAccountController.cs
+++ b/VirtoCommerce.Storefront/Controllers/Api/ApiAccountController.cs
@@ -113,38 +113,60 @@ namespace VirtoCommerce.Storefront.Controllers.Api
                 var user = await _userManager.FindByEmailAsync(orgRegistration.Email);
                 if (user != null)
                 {
-                    return IdentityResult.Failed(new IdentityError[] { new IdentityError() { Description = $"Email '{orgRegistration.Email}' is already taken." } });
-                }
-                user = await _userManager.FindByNameAsync(orgRegistration.UserName);
-                if (user == null)
-                {
-                    var organization = orgRegistration.ToOrganization();
-                    organization = await _memberService.CreateOrganizationAsync(organization);
-                    var contact = orgRegistration.ToContact();
-                    contact.OrganizationId = organization.Id;
-
-                    user = orgRegistration.ToUser();
-                    user.Contact = contact;
-                    user.StoreId = WorkContext.CurrentStore.Id;
-                    user.Roles = new[] { SecurityConstants.Roles.OrganizationMaintainer };
-
-                    result = await _userManager.CreateAsync(user, orgRegistration.Password);
-                    if (result.Succeeded)
+                    var error = new IdentityError
                     {
-                        user = await _userManager.FindByNameAsync(user.UserName);
-                        await _publisher.Publish(new UserRegisteredEvent(WorkContext, user, orgRegistration));
-                        await _signInManager.SignInAsync(user, isPersistent: true);
-                        await _publisher.Publish(new UserLoginEvent(WorkContext, user));
-                    }
+                        Description = $"Email '{orgRegistration.Email}' is already taken."
+                    };
+
+                    return IdentityResult.Failed(error);
+                }
+
+                user = await _userManager.FindByNameAsync(orgRegistration.UserName);
+                if (user != null)
+                {
+                    var error = new IdentityError
+                    {
+                        Description = $"User name '{orgRegistration.UserName}' is already taken."
+                    };
+
+                    return IdentityResult.Failed(error);
+                }
+
+                var organization = orgRegistration.ToOrganization();
+                organization = await _memberService.CreateOrganizationAsync(organization);
+                var contact = orgRegistration.ToContact();
+                contact.OrganizationId = organization.Id;
+
+                user = orgRegistration.ToUser();
+                user.Contact = contact;
+                user.StoreId = WorkContext.CurrentStore.Id;
+                user.Roles = new[]
+                             {
+                                 SecurityConstants.Roles.OrganizationMaintainer
+                             };
+
+                result = await _userManager.CreateAsync(user, orgRegistration.Password);
+                if (result.Succeeded)
+                {
+                    user = await _userManager.FindByNameAsync(user.UserName);
+                    await _publisher.Publish(new UserRegisteredEvent(WorkContext, user, orgRegistration));
+                    await _signInManager.SignInAsync(user, isPersistent: true);
+                    await _publisher.Publish(new UserLoginEvent(WorkContext, user));
                 }
                 else
                 {
-                    return IdentityResult.Failed(new IdentityError[] { new IdentityError() { Description = $"User name '{orgRegistration.UserName}' is already taken." } });
+                    // idle
                 }
             }
             else
             {
-                result = IdentityResult.Failed(ModelState.Values.SelectMany(x => x.Errors).Select(x => new IdentityError { Description = x.ErrorMessage }).ToArray());
+                var modelStateEntries = ModelState.Values.SelectMany(value => value.Errors);
+                var errors = modelStateEntries.Select(
+                    modelError => new IdentityError
+                    {
+                        Description = modelError.ErrorMessage
+                    });
+                result = IdentityResult.Failed(errors.ToArray());
             }
 
             return result;


### PR DESCRIPTION
Right now an empty organization is being created despite errors.
We should check if there is a user with same UserName or Email before creating an organization.